### PR TITLE
Update archive navigation to redirect to profile hub

### DIFF
--- a/404.html
+++ b/404.html
@@ -52,7 +52,7 @@
     <a href="gallery.html">comix</a>
     <a href="story.html">tales</a>
     <a href="blog.html">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
@@ -60,7 +60,7 @@
       <h1>404 - page not found</h1>
       <p>This path does not exist or has moved.</p>
       <p>
-        <a href="archive.html">Archive</a> |
+        <a href="profile.html#archive">Archive</a> |
         <a href="profile.html">Profile</a> |
         <a href="index.html">Top</a>
       </p>
@@ -68,7 +68,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 </body>
 </html>

--- a/archive.html
+++ b/archive.html
@@ -1,150 +1,60 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Archive hub for illustrations, comix, stories, blog, schedule, and profile.">
+  <meta name="description" content="Archive hub has moved to the main profile page.">
+  <meta http-equiv="refresh" content="0; url=profile.html#archive">
+  <link rel="canonical" href="https://irorinri.github.io/profile.html#archive">
   <title>Archive | irorinri</title>
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <link rel="stylesheet" href="styles.css">
   <style>
     main {
-      max-width: 760px;
-      margin: 0 auto;
-      padding: 1rem 1rem 3rem;
+      min-height: 68vh;
+      display: grid;
+      place-items: center;
+      padding: 1rem;
     }
 
-    .archive-intro {
-      margin: 0.4rem auto 1.1rem;
-      color: #444;
-      font-size: 0.95rem;
+    .redirect-card {
+      max-width: 460px;
+      padding: 1.2rem 1.3rem;
+      border: 1px solid #e4e4e4;
+      border-radius: 10px;
+      background: #fcfcfc;
       text-align: center;
     }
 
-    .archive-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 0.7rem;
-      margin-bottom: 1.2rem;
+    .redirect-card h1 {
+      margin: 0 0 0.45rem;
+      font-size: 1.18rem;
     }
 
-    .archive-card {
-      display: block;
-      padding: 0.9rem 0.8rem;
-      border: 1px solid #e2e2e2;
-      border-radius: 8px;
-      background: #fcfcfc;
-      color: #222;
-      text-decoration: none;
-      transition: background-color 0.2s ease, transform 0.2s ease;
-    }
-
-    .archive-card:hover {
-      background: #f7f7f7;
-      transform: translateY(-2px);
-    }
-
-    .archive-card h2 {
-      margin: 0 0 0.35rem;
-      font-size: 1.02rem;
-      font-weight: bold;
-    }
-
-    .archive-card p {
-      margin: 0;
+    .redirect-card p {
+      margin: 0 0 0.85rem;
       color: #555;
-      font-size: 0.88rem;
-      line-height: 1.5;
+      line-height: 1.6;
     }
 
-    .whats-new {
-      margin-bottom: 1rem;
-      padding: 0.9rem;
-      border: 1px solid #e2e2e2;
-      border-radius: 8px;
-      background: #fcfcfc;
-    }
-
-    .whats-new h2 {
-      margin: 0 0 0.5rem;
-      font-size: 1rem;
-      font-weight: bold;
-    }
-
-    .whats-new ul {
-      margin: 0;
-      padding-left: 1.15rem;
-    }
-
-    .whats-new li {
-      margin: 0.22rem 0;
-      font-size: 0.9rem;
-    }
-
-    @media (max-width: 600px) {
-      main {
-        padding: 0.8rem 1rem 2.5rem;
-      }
-
-      .archive-card {
-        padding: 0.85rem 0.75rem;
-      }
+    .redirect-card a {
+      color: inherit;
+      text-decoration: none;
+      border-bottom: 1px dotted #999;
     }
   </style>
+  <script>
+    window.location.replace('profile.html#archive');
+  </script>
 </head>
 <body>
-  <nav>
-    <a href="index.html">folks</a>
-    <a href="illustrations.html">draws</a>
-    <a href="gallery.html">comix</a>
-    <a href="story.html">tales</a>
-    <a href="blog.html">stuff</a>
-    <a href="archive.html" class="active" aria-current="page">archive</a>
-  </nav>
-
   <main>
-    <p class="archive-intro">New here? Start from this archive and jump to any corner.</p>
-
-    <section class="archive-grid" aria-label="Archive categories">
-      <a class="archive-card" href="illustrations.html">
-        <h2>Illustrations</h2>
-        <p>Main art archive and recent works.</p>
-      </a>
-      <a class="archive-card" href="gallery.html">
-        <h2>Comix</h2>
-        <p>Short comic pages and print-oriented works.</p>
-      </a>
-      <a class="archive-card" href="story.html">
-        <h2>Tales</h2>
-        <p>Story pages and serialized text pieces.</p>
-      </a>
-      <a class="archive-card" href="blog.html">
-        <h2>Blog</h2>
-        <p>Diary, chatter, snapshots, and notes.</p>
-      </a>
-      <a class="archive-card" href="schedule.html">
-        <h2>Schedule</h2>
-        <p>Weekly stream and creation routine.</p>
-      </a>
-      <a class="archive-card" href="profile.html">
-        <h2>Profile</h2>
-        <p>Main profile and social links.</p>
-      </a>
-    </section>
-
-    <section class="whats-new" aria-label="What's new">
-      <h2>What's new</h2>
-      <ul>
-        <li><a href="illustrations.html">Illustrations updated with the latest works</a></li>
-        <li><a href="blog.html#20250728">Blog note: 2025-07-28</a></li>
-        <li><a href="index.html">Characters page updates</a></li>
-      </ul>
+    <section class="redirect-card" aria-label="Archive moved">
+      <h1>Archive moved</h1>
+      <p>The main archive hub now lives on the profile page.</p>
+      <p><a href="profile.html#archive">Open the archive hub</a></p>
     </section>
   </main>
-
-  <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
-  </footer>
 </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -171,7 +171,7 @@
     <a href="gallery.html">comix</a>
     <a href="story.html">tales</a>
     <a href="blog.html" class="active" aria-current="page">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
@@ -247,7 +247,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 
   <script>

--- a/blog.html
+++ b/blog.html
@@ -9,6 +9,11 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <style>
+    html {
+      overflow-y: scroll;
+      scrollbar-gutter: stable;
+    }
+
     body.blog-page {
       font-size: 10px;
       line-height: 1.6;
@@ -258,20 +263,31 @@
     const visibleChatterLabels = 1;
 
     async function loadRecentEntries() {
-      const entries = document.querySelectorAll('[data-entry-file]');
+      const entries = Array.from(document.querySelectorAll('[data-entry-file]'));
 
-      for (const entry of entries) {
+      const results = await Promise.all(entries.map(async (entry) => {
         try {
           const response = await fetch(entry.dataset.entryFile);
           if (!response.ok) {
             throw new Error(`Failed to load ${entry.dataset.entryFile}`);
           }
-          entry.innerHTML = await response.text();
+
+          return {
+            entry,
+            html: await response.text(),
+          };
         } catch (error) {
-          entry.innerHTML = '<p>Failed to load this entry.</p>';
           console.error(error);
+          return {
+            entry,
+            html: '<p>Failed to load this entry.</p>',
+          };
         }
-      }
+      }));
+
+      results.forEach(({ entry, html }) => {
+        entry.innerHTML = html;
+      });
     }
 
     async function loadEmbeddedMain(url, target, fallbackText) {

--- a/blog2.html
+++ b/blog2.html
@@ -104,7 +104,7 @@
 
   <div class="home-btn-wrap">
     <a href="profile.html" class="home-btn">Home</a>
-    <a href="archive.html" class="home-btn">Archive</a>
+    <a href="profile.html#archive" class="home-btn">Archive</a>
   </div>
 
   <main>
@@ -136,7 +136,7 @@
   </main>
 
   <footer>
-  &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+  &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
 </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -54,7 +54,7 @@
     <section class="card contact-card">
       <div class="home-btn-group">
         <a href="profile.html" class="home-btn">Home</a>
-        <a href="archive.html" class="home-btn">Archive</a>
+        <a href="profile.html#archive" class="home-btn">Archive</a>
       </div>
 
       <p class="schedule-coming contact-heading">Find me here:</p>
@@ -69,7 +69,7 @@
     </section>
   </main>
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 </body>
 </html>

--- a/effect.css
+++ b/effect.css
@@ -299,3 +299,225 @@ footer a {
 
 
 
+
+.profile-hub .profile-hero {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 3.4rem 1rem 1rem;
+}
+
+.profile-hub .username {
+  margin-top: 0.45em;
+}
+
+.hero-kicker {
+  margin: 0 0 0.9rem;
+  color: #4f7ba4;
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.hero-summary {
+  max-width: 560px;
+  margin: 0.85rem auto 0;
+  color: #50627a;
+  font-size: 0.98rem;
+  line-height: 1.7;
+}
+
+.profile-main {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 3rem;
+}
+
+.profile-hub .card {
+  border-radius: 1.3rem;
+  margin: 0 0 1rem;
+  padding: 1.5rem;
+}
+
+.intro-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(220px, 0.9fr);
+  gap: 1rem;
+  align-items: center;
+}
+
+.intro-card h2 {
+  margin: 0 0 0.55rem;
+  color: var(--text-main);
+  font-size: 1.45rem;
+  letter-spacing: 0;
+}
+
+.intro-copy {
+  margin: 0;
+  color: #4d5c71;
+  font-size: 0.98rem;
+  line-height: 1.75;
+}
+
+.section-kicker {
+  margin: 0 0 0.35rem;
+  color: #6f92b8;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.section-head h2 {
+  margin: 0;
+  color: var(--text-main);
+  font-size: 1.35rem;
+  letter-spacing: 0;
+}
+
+.section-note {
+  max-width: 300px;
+  margin: 0;
+  color: #5f6f84;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  text-align: right;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  align-items: stretch;
+}
+
+.profile-hub .home-btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 44px;
+  border: 1px solid rgba(111, 146, 184, 0.22);
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.profile-hub .primary-btn {
+  background: #6f92b8;
+  color: #ffffff;
+}
+
+.profile-hub .primary-btn:hover,
+.profile-hub .primary-btn:active {
+  background: #587ca4;
+  color: #ffffff;
+}
+
+.hub-grid,
+.shortcut-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.hub-link,
+.shortcut-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.32rem;
+  min-height: 100%;
+  padding: 1rem;
+  border: 1px solid rgba(122, 144, 172, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.7);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.hub-link:hover,
+.shortcut-link:hover {
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 10px 26px rgba(60, 70, 140, 0.08);
+  transform: translateY(-2px);
+}
+
+.hub-link-title {
+  color: #47698e;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.hub-link-copy {
+  color: #55657b;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.update-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #425065;
+}
+
+.update-list li {
+  margin: 0.5rem 0;
+  line-height: 1.6;
+}
+
+.update-list a {
+  color: #47698e;
+  text-decoration: none;
+}
+
+.update-list a:hover {
+  text-decoration: underline;
+}
+
+.shortcut-link {
+  justify-content: center;
+  min-height: 72px;
+  color: #47698e;
+  font-weight: 600;
+  text-align: center;
+}
+
+@media (max-width: 820px) {
+  .intro-card,
+  .hub-grid,
+  .shortcut-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .profile-hub .profile-hero {
+    padding-top: 2.5rem;
+  }
+
+  .section-head {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .section-note {
+    max-width: none;
+    text-align: left;
+  }
+
+  .intro-card,
+  .hub-grid,
+  .shortcut-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-summary {
+    font-size: 0.93rem;
+  }
+}

--- a/gallery.html
+++ b/gallery.html
@@ -82,7 +82,7 @@
     <a href="gallery.html" class="active" aria-current="page">comix</a>
     <a href="story.html">tales</a>
     <a href="blog.html">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
@@ -124,7 +124,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 
   <script type="module">

--- a/icon.html
+++ b/icon.html
@@ -25,7 +25,7 @@
 <body>
   <nav>
     <a href="blog.html">Stuff</a>
-    <a href="archive.html">Archive</a>
+    <a href="profile.html#archive">Archive</a>
   </nav>
 
   <main>
@@ -80,7 +80,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 </body>
 </html>

--- a/illustrations.html
+++ b/illustrations.html
@@ -104,7 +104,7 @@
     <a href="gallery.html">comix</a>
     <a href="story.html">tales</a>
     <a href="blog.html">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
@@ -117,7 +117,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 
   <script type="module">

--- a/index.html
+++ b/index.html
@@ -27,42 +27,34 @@
       padding: 0 1rem 3rem;
     }
 
-    .start-here {
-      margin: 0 auto 1.2rem;
+    .page-intro {
+      margin: 0 auto 1.25rem;
       max-width: 780px;
-      padding: 0.55rem 0.8rem;
-      border: 1px solid #e6e6e6;
-      border-radius: 6px;
-      background: #f8f8f8;
+      padding: 1rem 1.1rem;
+      border: 1px solid #e5e5e5;
+      border-radius: 10px;
+      background: #f9f9f9;
       text-align: center;
     }
 
-    .start-here-copy {
-      margin: 0 0 0.15rem;
-      color: #444;
-      font-size: 0.9rem;
+    .page-intro h1 {
+      margin: 0 0 0.45rem;
+      color: var(--text-main);
+      font-size: 1.2rem;
     }
 
-    .start-here-links {
+    .page-intro p {
       margin: 0;
-      font-size: 0.86rem;
-      line-height: 1.5;
+      color: #4b4b4b;
+      font-size: 0.92rem;
+      line-height: 1.65;
     }
 
-    .start-here-links a {
-      color: inherit;
-    }
-
-    .profile-link-wrap {
-      display: flex;
-      justify-content: center;
-      margin: 4rem 0 1rem;
-    }
-
-    .profile-link {
+    .page-intro-link {
       display: inline-block;
-      padding: 0.5em 1.4em;
-      border-radius: 0.2em;
+      margin-top: 0.9rem;
+      padding: 0.55em 1.35em;
+      border-radius: 999px;
       background: var(--accent);
       color: #fff;
       font-size: 0.95em;
@@ -71,7 +63,7 @@
       transition: background 0.2s, color 0.2s;
     }
 
-    .profile-link:hover {
+    .page-intro-link:hover {
       background: var(--accent2);
       color: var(--text-main);
     }
@@ -117,25 +109,15 @@
     <a href="gallery.html">comix</a>
     <a href="story.html">tales</a>
     <a href="blog.html">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
-    <section class="start-here" aria-label="Start here">
-      <p class="start-here-copy">New here? Start from Archive.</p>
-      <p class="start-here-links">
-        <a href="archive.html">Archive</a> |
-        <a href="illustrations.html">Illustrations</a> |
-        <a href="gallery.html">Comix</a> |
-        <a href="blog.html">Blog</a> |
-        <a href="schedule.html">Schedule</a> |
-        <a href="profile.html">Profile</a>
-      </p>
+    <section class="page-intro" aria-label="Page intro">
+      <h1>Folks archive</h1>
+      <p>This page is now focused on the character posts only. The main archive hub lives on the profile page, so use that when you want the full site map.</p>
+      <a class="page-intro-link" href="profile.html#archive">Open Profile Hub</a>
     </section>
-
-    <div class="profile-link-wrap">
-      <a class="profile-link" href="profile.html">Profile</a>
-    </div>
 
     <div class="image-gallery">
       <a href="images/d.webp" data-pswp-width="1920" data-pswp-height="1920">
@@ -170,7 +152,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 
   <script type="module">

--- a/profile.html
+++ b/profile.html
@@ -3,28 +3,32 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Profile hub for irorinri with links to blog, archive, schedule, art, and contact.">
-  <meta property="og:title" content="Huelin | Vtuber Portfolio">
-  <meta property="og:description" content="Profile hub with archive, blog, schedule, and social links.">
+  <meta name="description" content="Main profile and archive hub for irorinri with direct links to folks, illustrations, comix, tales, blog, schedule, and contact.">
+  <meta property="og:title" content="Profile & Archive | irorinri">
+  <meta property="og:description" content="Main profile and archive hub with direct paths to every section of the site.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://irorinri.github.io/profile.html">
   <meta property="og:image" content="https://irorinri.github.io/profile.webp">
-  <title>Huelin | Vtuber Portfolio</title>
+  <title>Profile & Archive | irorinri</title>
+  <link rel="icon" href="favicon.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" href="apple-touch-icon.png">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="effect.css">
 </head>
-<body>
+<body class="profile-hub">
   <div class="glow-bg"></div>
 
-  <header>
+  <header class="profile-hero">
+    <p class="hero-kicker">Profile / Archive Hub</p>
     <div class="avatar-wrap">
       <img src="profile.webp" alt="Huelin avatar" class="avatar">
     </div>
-    <div class="username">Huelin!</div>
+    <h1 class="username">Huelin!</h1>
     <div class="subtitle">
       streamer / developer<br>
       <span class="location">Based in Japan</span>
     </div>
+    <p class="hero-summary">This page is now the front door for the whole site: archive, posts, gallery, schedule, and contact.</p>
     <nav class="socials" aria-label="Social links">
       <a href="https://irorinri.bandcamp.com/"><img src="bandcamp.svg" alt="Bandcamp"></a>
       <a href="https://sketchfab.com/irorinri"><img src="sketchfab.svg" alt="Sketchfab"></a>
@@ -34,20 +38,100 @@
     </nav>
   </header>
 
-  <main>
-    <section class="card">
-      <ul>
-        <li><a href="blog2.html">Blog</a></li>
-        <li><a href="archive.html">Archive Hub</a></li>
-        <li><a href="schedule.html">Stream Schedule</a></li>
-        <li><a href="illustrations.html">Art Gallery</a></li>
-        <li><a href="contact.html">Contact</a></li>
+  <main class="profile-main">
+    <section class="card intro-card">
+      <div>
+        <p class="section-kicker">Start here</p>
+        <h2>Everything is linked from this page now.</h2>
+        <p class="intro-copy">Use the archive section below to move through folks, drawings, comix, tales, blog posts, and the utility pages without bouncing between duplicate menus.</p>
+      </div>
+      <div class="hero-actions">
+        <a href="#archive" class="home-btn primary-btn">Browse Archive</a>
+        <a href="blog.html#20250728" class="home-btn">Latest Note</a>
+      </div>
+    </section>
+
+    <section id="archive" class="card hub-section">
+      <div class="section-head">
+        <div>
+          <p class="section-kicker">Archive</p>
+          <h2>Explore the site</h2>
+        </div>
+        <p class="section-note">Major sections first, then the smaller support pages.</p>
+      </div>
+      <div class="hub-grid" aria-label="Archive links">
+        <a class="hub-link" href="index.html">
+          <span class="hub-link-title">Folks</span>
+          <span class="hub-link-copy">Character archive and the newest profile-focused posts.</span>
+        </a>
+        <a class="hub-link" href="illustrations.html">
+          <span class="hub-link-title">Illustrations</span>
+          <span class="hub-link-copy">Main drawing archive with the latest work first.</span>
+        </a>
+        <a class="hub-link" href="gallery.html">
+          <span class="hub-link-title">Comix</span>
+          <span class="hub-link-copy">Short comic pages and print-oriented pieces.</span>
+        </a>
+        <a class="hub-link" href="story.html">
+          <span class="hub-link-title">Tales</span>
+          <span class="hub-link-copy">Serialized text stories and visual previews.</span>
+        </a>
+        <a class="hub-link" href="blog.html">
+          <span class="hub-link-title">Stuff</span>
+          <span class="hub-link-copy">Recent notes, diary, chatter, and embedded side pages.</span>
+        </a>
+        <a class="hub-link" href="blog2.html">
+          <span class="hub-link-title">Blog Index</span>
+          <span class="hub-link-copy">A compact list of blog entries when you want direct jumps.</span>
+        </a>
+        <a class="hub-link" href="schedule.html">
+          <span class="hub-link-title">Schedule</span>
+          <span class="hub-link-copy">Weekly creation and streaming rhythm.</span>
+        </a>
+        <a class="hub-link" href="contact.html">
+          <span class="hub-link-title">Contact</span>
+          <span class="hub-link-copy">External links and the best places to reach me.</span>
+        </a>
+        <a class="hub-link" href="icon.html">
+          <span class="hub-link-title">Icons & Snapshot</span>
+          <span class="hub-link-copy">Past icons, cropped visuals, and snapshot archive.</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="card updates-section">
+      <div class="section-head">
+        <div>
+          <p class="section-kicker">Latest</p>
+          <h2>Recent updates</h2>
+        </div>
+      </div>
+      <ul class="update-list">
+        <li><a href="illustrations.html">2026-02-28: illustration archive update</a></li>
+        <li><a href="icon.html">2026-01-09: icon archive update</a></li>
+        <li><a href="blog.html#20250728">2025-07-28: latest note, The Ocean AItuber</a></li>
+        <li><a href="index.html">2024-09-13: newest folks page character post</a></li>
       </ul>
+    </section>
+
+    <section class="card shortcut-section">
+      <div class="section-head">
+        <div>
+          <p class="section-kicker">Quick paths</p>
+          <h2>Useful jumps</h2>
+        </div>
+      </div>
+      <div class="shortcut-grid" aria-label="Quick links">
+        <a class="shortcut-link" href="https://suzuri.jp/Irorinri" target="_blank" rel="noopener">Buy Stickers</a>
+        <a class="shortcut-link" href="https://irorinri.booth.pm/items/7206655" target="_blank" rel="noopener">Buy Print</a>
+        <a class="shortcut-link" href="https://irorinri.booth.pm/items/7156017" target="_blank" rel="noopener">Read Tales in print</a>
+        <a class="shortcut-link" href="https://github.com/irorinri" target="_blank" rel="noopener">GitHub profile</a>
+      </div>
     </section>
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="#archive">Archive</a> | <a href="contact.html">Contact</a>
   </footer>
 </body>
 </html>

--- a/schedule.html
+++ b/schedule.html
@@ -206,7 +206,7 @@
     <div class="schedule-card">
       <div class="home-btn-wrap">
         <a href="profile.html" class="home-btn">Home</a>
-        <a href="archive.html" class="home-btn">Archive</a>
+        <a href="profile.html#archive" class="home-btn">Archive</a>
       </div>
       <h1 class="schedule-title">Weekly Stream Schedule</h1>
       <p class="schedule-note">Streaming and creating about 2 hours a day!</p>
@@ -235,7 +235,7 @@
     </div>
   </main>
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 </body>
 </html>

--- a/story.html
+++ b/story.html
@@ -109,7 +109,7 @@
     <a href="gallery.html">comix</a>
     <a href="story.html" class="active" aria-current="page">tales</a>
     <a href="blog.html">stuff</a>
-    <a href="archive.html">archive</a>
+    <a href="profile.html#archive">archive</a>
   </nav>
 
   <main>
@@ -147,7 +147,7 @@
   </main>
 
   <footer>
-    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="archive.html">Archive</a>
+    &copy; irorinri | <a href="profile.html">Profile</a> | <a href="profile.html#archive">Archive</a>
   </footer>
 
   <script>


### PR DESCRIPTION
## Summary
- move the archive hub content onto `profile.html`, add hero sections, hub links, and layout styles so the profile page is now the primary entry point
- redirect old archive references (nav links, footer links, 404 page, and standalone archive.html) to `profile.html#archive` to prevent duplicate headers and maintain a single hub
- refresh other pages’ nav/footer copy to match the new single-source layout and tighten header styling so the blog header jump is gone

## Testing
- Not run (not requested)